### PR TITLE
Bugfix: str-replace when $old at beginning of string

### DIFF
--- a/stylesheets/SassyStrings/_str-replace.scss
+++ b/stylesheets/SassyStrings/_str-replace.scss
@@ -12,7 +12,7 @@
   $index: if(not $case-sensitive, str-index(to-lower-case($string), to-lower-case($old)),  str-index($string, $old));
 
   @if $index > 0 and $new != $old {
-    $result: quote(str-slice($string, 1, $index - 1));
+    $result: if($index > 1, quote(str-slice($string, 1, $index - 1)), '');
 
     @for $i from $index through str-length($string) {
       @if $i < $index or $i >= $index + str-length($old) {


### PR DESCRIPTION
Hi,
there's a bug with str-replace when the `$old` string is found at the beginning of `$string`. In other words when `str-index()` returns 1.
This patch intends to fix it.

PS: keep up the good work!
